### PR TITLE
Fix libthymesisflow build issue

### DIFF
--- a/libthymesisflow/CMakeLists.txt
+++ b/libthymesisflow/CMakeLists.txt
@@ -29,7 +29,7 @@ if (MOCK)
 endif()
 
 include(GNUInstallDirs)
-install(TARGETS thymesisf-cli thymesisf-agent)
+install(TARGETS thymesisf-cli thymesisf-agent DESTINATION bin)
 install(FILES thymesisf-agent@.service DESTINATION etc/systemd/system)
 
 enable_testing()


### PR DESCRIPTION
Fixed libthymesisflow build issue

```
➜ cmake ../ -DMOCK=0       
CMake Error at CMakeLists.txt:32 (install):
  install TARGETS given no RUNTIME DESTINATION for executable target
  "thymesisf-cli".
```
Added destination to the binary targets (`thymesiflow-cli`, `thymesisflow-agent`). Should anyone ever install it will do it on `/usr/local/lib`.